### PR TITLE
Add use_existing_torch.py for user who don't want to reinstall torch

### DIFF
--- a/use_existing_torch.py
+++ b/use_existing_torch.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import glob
+
+requires_files = glob.glob('requirements.txt')
+requires_files += ["pyproject.toml"]
+for file in requires_files:
+    print(f">>> cleaning {file}")
+    with open(file) as f:
+        lines = f.readlines()
+    if "torch" in "".join(lines).lower():
+        print("removed:")
+        with open(file, 'w') as f:
+            for line in lines:
+                if 'torch' not in line.lower():
+                    f.write(line)
+                else:
+                    print(line.strip())
+    print(f"<<< done cleaning {file}")
+    print()


### PR DESCRIPTION
For supporting NVIDIA 50 series GPU which uses CUDA 12.8, we can't reinstall torch. This PR adds use_existing_torch.py for user who don't want to reinstall torch. To install torchac_cuda without reinstalling torch, run the following commands:

```shell
git clone https://github.com/LMCache/torchac_cuda.git
cd torchac_cuda
python use_existing_torch.py
pip install -r requirements.txt
pip install -e . --no-build-isolation
```