### PR TITLE
[bug fix] pin pytorch 2.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools >= 49.4.0",
-    "torch >= 2.1.0",
+    "torch == 2.6.0",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     include_package_data = True,
     ext_modules=[
         cpp_extension.CUDAExtension(
-            'torchac_cuda', 
+            'torchac_cuda',
             [
                 'main.cpp',
                 'torchac_kernel_enc_new.cu',
@@ -23,12 +23,12 @@ setup(
             },
             include_dirs=['./include']
             ),
-        
+
     ],
     cmdclass={
         'build_ext': cpp_extension.BuildExtension
     },
     install_requires = [
-        "torch >= 2.1.0",
+        "torch == 2.6.0",
     ]
 )


### PR DESCRIPTION
pytorch 2.7.0 was released today and forces the use of CXX11 ABI.

cc @tlrmchlsmth